### PR TITLE
Add more features to the paragraph editor.

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -33,7 +33,8 @@ class PostPage(Page):
     description = models.CharField("Descripción", max_length=255, blank=True)
     image = models.ImageField("Imagen principal", blank=True, null=True)
 
-    editor_features = ['h2', 'h3', 'bold', 'italic', 'link', 'code',
+    editor_features = ['h2', 'h3', 'h4', 'bold', 'italic', 'link', 'code',
+                       'ol', 'ul', 'hr', 'document-link', 'image', 'embed',
                        'strikethrough', 'blockquote']
     body = StreamField([
         ('heading', blocks.CharBlock(classname="full title")),

--- a/blog/models.py
+++ b/blog/models.py
@@ -33,9 +33,11 @@ class PostPage(Page):
     description = models.CharField("Descripción", max_length=255, blank=True)
     image = models.ImageField("Imagen principal", blank=True, null=True)
 
+    editor_features = ['h2', 'h3', 'bold', 'italic', 'link', 'code',
+                       'strikethrough', 'blockquote']
     body = StreamField([
         ('heading', blocks.CharBlock(classname="full title")),
-        ('paragraph', blocks.RichTextBlock()),
+        ('paragraph', blocks.RichTextBlock(features=editor_features)),
         ('code', CodeBlock(label='Code')),
         ('image', ImageChooserBlock()),
 


### PR DESCRIPTION
By default the wagtail editor contains a couple of default
options, like h1, h2, bold, italic, etc, but does not include
extra options like:
- inline code,
- strikethrough,
- blockquote.

this adds those options to the current editor options.
(Documentation reference: 2.8.1 - Customising the editing interface)