### PR TITLE
Change color of default links

### DIFF
--- a/pythonchile_v2/static/css/clean-blog.css
+++ b/pythonchile_v2/static/css/clean-blog.css
@@ -30,12 +30,12 @@ h6 {
 }
 
 a {
-  color: #212529;
+  color: #0085A1;
   transition: all 0.2s;
 }
 
 a:focus, a:hover {
-  color: #0085A1;
+  color: #00687d;
 }
 
 blockquote {


### PR DESCRIPTION
Leaving the a:hover effect to be an underline,
but changing the default links color to distinguish them
from the normal text.